### PR TITLE
3 refactor send functions to send to zarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install the **OceanDataStore** package, first clone the repository from GitHu
 git clone git@github.com:NOC-MSM/OceanDataStore.git
 ```
 
-Next, install **OceanDataStore** in editable mode by:
+Next, install **OceanDataStore** in editable mode as follows:
 
 ```bash
 cd OceanDataStore
@@ -36,10 +36,10 @@ To get started using **OceanDataStore**, users need to create a ``credentials.js
 
 ### Sending Individual Files
 
-To create a new zarr store in an object store from a local file, use the `send` command:
+To create a new zarr store in an object store from a local file, use the `send_to_zarr` command:
 
 ```bash
-ods send -f /path/to/file.nc -c credentials.json -b bucket_name -v var
+ods send_to_zarr -f /path/to/file.nc -c credentials.json -b bucket_name -v var
 ```
 
 The arguments used are:
@@ -52,13 +52,13 @@ In the example above, without a `-p` (or `--prefix`), the variables will be stor
 
 ### Sending Lots of Files
 
-To create a new zarr store in an object store from a large number of files, we can use [dask](https://www.dask.org) via the `send_with_dask` command:
+To create a new zarr store in an object store using a large number of files, we can use [dask](https://www.dask.org) with the `send_to_zarr` command by passing a dask configuration JSON file:
 
 ```bash
-ods send_with_dask -f filepaths -c credentials.json -b bucket_name -p prefix \
-                      -gf filepath_domain -uc '{"lat":"lat_new", "lon":"lon_new"}' \
-                      -cs '{"x":500, "y":500, "depthw":25}' \
-                      -dc dask_config.json
+ods send_to_zarr -f filepaths -c credentials.json -b bucket_name -p prefix \
+                 -gf filepath_domain -uc '{"lat":"lat_new", "lon":"lon_new"}' \
+                 -cs '{"x":500, "y":500, "depthw":25}' \
+                 -dc dask_config.json
 ```
 
 The arguments used are:
@@ -89,31 +89,31 @@ where the contents of the ``dask_config.json`` are:
 
 In the example, a LocalCluster with 12 single threaded workers, each with 2 GB of available memory, is used to transfer a large collection of files to an object store.
 
-Users are recommended to implement send_with_dask workflows using a job scheduler, such as SLURM or PBS, to run the LocalCluster on a single compute node.
+Users are strongly recommended to implement `send_to_zarr` workflows using a job scheduler, such as SLURM or PBS, to either run the LocalCluster on a single compute node or to use an existing the SLURMCluster or PBSCluster (dask job queue).
 
-**Note:** the netCDF4 library does not support multi-threaded access to datasets, so users should ensure that ``threads_per_worker : 1`` in their dask configuration .json file to avoid raising CancelledError exceptions when using send_with_dask or update_with_dask.
+**Note:** the netCDF4 library does not support multi-threaded access to datasets, so users should ensure that ``threads_per_worker : 1`` in their dask configuration JSON file to avoid raising CancelledError exceptions when using ``send_to_zarr`` or `update_zarr`.
 
 ### Updating Existing Stores
 
-To update an existing zarr store in an object store, we can use the `update` command:
+To update an existing zarr store in an object store, we can use the `update_zarr` command:
 
 ```bash
-ods update -f /path/to/file.nc -c credentials.json -b bucket_name -p prefix -v var
+ods update_zarr -f /path/to/file.nc -c credentials.json -b bucket_name -p prefix -v var
 ```
 
-This command will append the values of variable `var` stored at the local filepath to the `/bucket_name/prefix/var` store provided it already exists in the object store.
+This command will replace and/or append the values of variable `var` stored at the local filepath to the `/bucket_name/prefix/var` store provided it already exists in the object store.
 
 **Note:** compatability checks must be passed before local data will be appended to an existing store, these include chunk size & dimension compatability.
 
 ### Updating Existing Stores With Lots of Files
 
-To update an existing zarr store in an object store using a large number of files, we can use the `update_with_dask` command analogously to `send_with_dask`:
+To update an existing zarr store in an object store using a large number of files, we can use [dask](https://www.dask.org) via the `update_zarr` command analogously to `send_to_zarr`:
 
 ```bash
-ods update_with_dask -f filepaths -c credentials.json -b bucket_name -p prefix \
-                        -gf filepath_domain -uc '{"lat":"lat_new", "lon":"lon_new"}' \
-                        -cs '{"x":500, "y":500, "depthw":25}' -ad time \
-                        -dc dask_config.json
+ods update_zarr -f filepaths -c credentials.json -b bucket_name -p prefix \
+                -gf filepath_domain -uc '{"lat":"lat_new", "lon":"lon_new"}' \
+                -cs '{"x":500, "y":500, "depthw":25}' -ad time \
+                -dc dask_config.json
 ```
 
 ## Examples

--- a/examples/example_send_script.sh
+++ b/examples/example_send_script.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-# Example script to send a single file to the object store using msm_os
-# send() function.
-# Originally created by:
-# - Ollie Tooth (17/03/2025)
 
 # ----------------------------------------------------------------------------- #
-#                                                                               #
-#     Example: Using send() to create a zarr store from a batch of files        #
-#                                                                               #
+#
+# Example 1: Using send_to_zarr() to create a zarr store from a single file.
+#
+# Description: Example script to send a single file to the object store using
+# send_to_zarr() function.
+#
+# Created by: Ollie Tooth (oliver.tooth@noc.ac.uk) on 17/03/2025
+#
 # ----------------------------------------------------------------------------- #
 
 # -- Input arguments to msm-os -- #
@@ -51,8 +52,8 @@ fi
 
 # -- Send eORCA1 ERA-5 annual mean outputs to object store -- # 
 echo "In Progress: Sending example eORCA1 ERA-5 T1y file to object store..."
-msm_os send -f "$filepath_gridT" -c "$store_credentials_json" -b "$bucket" -p T1y \
-            -gf "$filepath_grid" -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
-            -cs '{"x":360,"y":331,"deptht":25}' || { echo "Error: msm_os send command failed."; exit 1; }
+ods send_to_zarr -f "$filepath_gridT" -c "$store_credentials_json" -b "$bucket" -p T1y \
+                -gf "$filepath_grid" -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                -cs '{"x":360,"y":331,"deptht":25}' || { echo "Error: ods send command failed."; exit 1; }
 
-echo "Success: File sent to object store."
+echo "Success: Sent file to eORCA1 ERA-5 T1y zarr store."

--- a/examples/example_send_with_dask_script.sh
+++ b/examples/example_send_with_dask_script.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-# Example script to send a batch of files to the object store using msm_os
-# send_with_dask() function.
-# Originally created by:
-# - Ollie Tooth (17/03/2025)
 
 # ----------------------------------------------------------------------------- #
-#                                                                               #
-# Example: Using send_with_dask() to create a zarr store from a batch of files  #
-#                                                                               #
+#
+# Example 2: Using send_to_zarr() to create a zarr store from a batch of files
+#
+# Description: Example script to send multiple files to the object store using
+# send_to_zarr() function.
+#
+# Created by: Ollie Tooth (oliver.tooth@noc.ac.uk) on 17/03/2025
+#
 # ----------------------------------------------------------------------------- #
 
 # -- Input arguments to msm-os -- #
@@ -59,9 +60,9 @@ fi
 
 # -- Send eORCA1 ERA-5 annual mean outputs to JASMIN OS -- # 
 echo "In Progress: Sending eORCA1 ERA-5 T1y variables to JASMIN object store..."
-msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
-                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
-                      -cs '{"x":360,"y":331,"deptht":25}' \
-                      -dc $dask_config_json || { echo "Error: msm_os send_with_dask command failed."; exit 1; }
+ods send_to_zarr -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
+                 -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                 -cs '{"x":360,"y":331,"deptht":25}' \
+                 -dc $dask_config_json || { echo "Error: ods send_to_zarr command failed."; exit 1; }
 
-echo "Success: Files sent to object store."
+echo "Success: Sent files to eORCA1 ERA-5 T1y zarr store."

--- a/examples/example_update_script.sh
+++ b/examples/example_update_script.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-# Example script to send a update file in the object store using msm_os
-# update() function.
-# Originally created by:
-# - Ollie Tooth (27/03/2025)
 
 # ----------------------------------------------------------------------------- #
-#                                                                               #
-#     Example: Using update() to create a zarr store from a batch of files      #
-#                                                                               #
+#
+# Example 3: Using update_zarr() to update a zarr store using single file.
+#
+# Description: Example script to update an existing zarr store in an object store
+# using update_zarr() function.
+#
+# Created by: Ollie Tooth (oliver.tooth@noc.ac.uk) on 17/03/2025
+#
 # ----------------------------------------------------------------------------- #
 
 # -- Input arguments to msm-os -- #
@@ -54,9 +55,9 @@ fi
 
 # -- Send eORCA1 ERA-5 annual mean outputs to object store -- # 
 echo "In Progress: Sending example eORCA1 ERA-5 T1y file to object store..."
-msm_os update -f "$filepath_gridT" -c "$store_credentials_json" -b "$bucket" -p T1y \
-              -gf "$filepath_grid" -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
-              -a $append_dim \
-              -cs '{"x":360,"y":331,"deptht":25}' || { echo "Error: msm_os update command failed."; exit 1; }
+ods update_zarr -f "$filepath_gridT" -c "$store_credentials_json" -b "$bucket" -p T1y \
+                -gf "$filepath_grid" -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                -a $append_dim \
+                -cs '{"x":360,"y":331,"deptht":25}' || { echo "Error: ods update command failed."; exit 1; }
 
-echo "Success: File sent to object store."
+echo "Success: Updated eORCA1 ERA-5 T1y zarr store."

--- a/examples/example_update_with_dask_script.sh
+++ b/examples/example_update_with_dask_script.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# Example script to send a batch of files to the object store using msm_os
-# update_with_dask() function.
-# Originally created by:
-# - Ollie Tooth (17/03/2025)
 
-# --------------------------------------------------------------------------------- #
-#                                                                                   #
-# Example: Using update_with_dask() to create a zarr store from a batch of files    #
-#                                                                                   #
-# --------------------------------------------------------------------------------- #
+# ----------------------------------------------------------------------------- #
+#
+# Example 4: Using update_zarr() to update a zarr store using mulitple files.
+#
+# Description: Example script to update an existing zarr store in an object store
+# using update_zarr() function.
+#
+# Created by: Ollie Tooth (oliver.tooth@noc.ac.uk) on 17/03/2025
+#
+# ----------------------------------------------------------------------------- #
 
 # -- Input arguments to msm-os -- #
 # Filepath to eORCA1 ancillary file:
@@ -59,9 +60,9 @@ fi
 
 # -- Send eORCA1 ERA-5 annual mean outputs to JASMIN OS -- # 
 echo "In Progress: Sending eORCA1 ERA-5 T1y variables to JASMIN object store..."
-msm_os update_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
-                       -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
-                       -cs '{"x":360,"y":331,"deptht":25}' \
-                       -dc $dask_config_json || { echo "Error: msm_os update_with_dask command failed."; exit 1; }
+ods update_zarr -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
+                -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                -cs '{"x":360,"y":331,"deptht":25}' \
+                -dc $dask_config_json || { echo "Error: ods update_with_dask command failed."; exit 1; }
 
-echo "Success: Files sent to object store."
+echo "Success: Updated eORCA1 ERA-5 T1y zarr store."

--- a/examples/example_update_with_dask_script.sh
+++ b/examples/example_update_with_dask_script.sh
@@ -2,7 +2,7 @@
 
 # ----------------------------------------------------------------------------- #
 #
-# Example 4: Using update_zarr() to update a zarr store using mulitple files.
+# Example 4: Using update_zarr() to update a zarr store using multiple files.
 #
 # Description: Example script to update an existing zarr store in an object store
 # using update_zarr() function.

--- a/ods/cli/argument_parser.py
+++ b/ods/cli/argument_parser.py
@@ -26,7 +26,7 @@ def create_parser():
     # Send and Update are mutually exclusive operations
     parser.add_argument(
         "action",
-        choices=["send", "send_with_dask", "update", "update_with_dask", "list"],
+        choices=["send_to_zarr", "update_zarr", "update", "update_with_dask", "list"],
         help="Specify the action: 'send' or 'send_with_dask' to send a file to an object store, "
         "'update' to update an existing object, or 'list' to list the files in a bucket.",
     )

--- a/ods/cli/main_cli.py
+++ b/ods/cli/main_cli.py
@@ -14,7 +14,7 @@ import sys
 import json
 import logging
 
-from ..object_store_handler import send, send_with_dask, update, update_with_dask, list_objects
+from ..object_store_handler import send_to_zarr, update_zarr, update, update_with_dask, list_objects
 from .argument_parser import __version__, create_parser
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,12 @@ def process_action(args):
     if args.zarr_version is not None:
         zarr_version = int(args.zarr_version)
 
-    if args.dask_config_json is not None:
+    if args.dask_config_json is None:
+        dask_config = {
+            "config_kwargs": None,
+            "cluster_kwargs": None,
+        }
+    else:
         dask_config = json.load(open(args.dask_config_json))
         if "config_kwargs" not in dask_config:
             raise ValueError("config_kwargs not found in Dask configuration.")
@@ -82,26 +87,9 @@ def process_action(args):
             raise ValueError("cluster_kwargs not found in Dask configuration.")
 
     # === Process Actions === #
-    if args.action == "send":
+    if args.action == "send_to_zarr":
 
-        send(
-            file=filepaths,
-            bucket=args.bucket,
-            object_prefix=args.object_prefix,
-            store_credentials_json=args.store_credentials_json,
-            variables=variables,
-            append_dim=args.append_dim,
-            send_vars_indep=send_vars_indep,
-            grid_filepath=args.grid_filepath,
-            update_coords=args.update_coords,
-            rechunk=args.chunk_strategy,
-            attrs=args.attrs,
-            zarr_version=zarr_version,
-        )
-
-    elif args.action == "send_with_dask":
-
-        send_with_dask(
+        send_to_zarr(
             file=filepaths,
             bucket=args.bucket,
             object_prefix=args.object_prefix,
@@ -117,6 +105,25 @@ def process_action(args):
             dask_cluster_kwargs=dask_config["cluster_kwargs"],
             zarr_version=zarr_version,
         )
+    
+    elif args.action == "update_zarr":
+
+        update_zarr(
+            file=filepaths,
+            bucket=args.bucket,
+            object_prefix=args.object_prefix,
+            store_credentials_json=args.store_credentials_json,
+            variables=variables,
+            send_vars_indep=send_vars_indep,
+            append_dim=args.append_dim,
+            grid_filepath=args.grid_filepath,
+            update_coords=args.update_coords,
+            rechunk=args.chunk_strategy,
+            attrs=args.attrs,
+            dask_config_kwargs=dask_config["config_kwargs"],
+            dask_cluster_kwargs=dask_config["cluster_kwargs"],
+            zarr_version=zarr_version,
+            )
 
     elif args.action == "update":
 

--- a/ods/object_store_handler.py
+++ b/ods/object_store_handler.py
@@ -663,7 +663,7 @@ def send_with_dask(
     dask_config_kwargs: Optional[dict] = None,
     dask_cluster_kwargs: Optional[dict] = None,
     zarr_version: int = 3
-) -> None:
+    ) -> None:
     """
     Write data in parallel to new zarr store in cloud object storage
     using dask local cluster.
@@ -700,14 +700,6 @@ def send_with_dask(
     zarr_version: int, default=3
         Zarr version to use.
     """
-    # == Verify Inputs == #
-    if dask_config_kwargs is not None:
-        if not isinstance(dask_config_kwargs, dict):
-            raise TypeError("dask_config_kwargs must be a dictionary.")
-    if dask_cluster_kwargs is not None:
-        if not isinstance(dask_cluster_kwargs, dict):
-            raise TypeError("dask_cluster_kwargs must be a dictionary.")
-
     # === Configure Cluster === #
     # Update dask configuration settings:
     if dask_config_kwargs is not None:
@@ -781,6 +773,93 @@ def send_with_dask(
         logging.info("Dask Cluster has been shutdown.")
 
 
+def send_to_zarr(
+    file: list[str] | str,
+    bucket: str,
+    object_prefix: str,
+    store_credentials_json: str,
+    variables: list[str] | str = 'all',
+    send_vars_indep: bool = True,
+    append_dim: str = "time_counter",
+    grid_filepath: Optional[str] = None,
+    update_coords: Optional[dict] = None,
+    rechunk: Optional[dict] = None,
+    attrs: Optional[dict] = None,
+    dask_config_kwargs: Optional[dict] = None,
+    dask_cluster_kwargs: Optional[dict] = None,
+    zarr_version: int = 3
+    ) -> None:
+    """
+    Send files to new zarr store in cloud object storage
+    in serial or in parallel using a dask local cluster.
+
+    Parameters
+    ----------
+    file: list | str
+        Regular expression or list of filepaths to netCDF file(s).
+    bucket: str
+        Name of the bucket in the object store. Bucket names can contain only
+        lowercase letters, numbers, dots (.), and hyphens (-).
+    object_prefix: str
+        Prefix to be added to the object names in the object store.
+    store_credentials_json: str
+        Path to the JSON file containing the object store credentials.
+    variables: list | str, default="all"
+        List of variables to send. If None, all variables will be sent.
+    send_vars_indep: bool, default=True
+        Whether to send variables as separate objects, by default True.
+    append_dim: str, default="time_counter"
+        Name of the append dimension, by default "time_counter".
+    grid_filepath: str, optional
+        Path to file containing model grid parameter.
+    update_coords: dict, optional
+        Dictionary of coordinate variables to update.
+    rechunk: dict, optional
+        Rechunk strategy dictionary, by default None.
+    attrs: dict, optional
+        Attributes to add to the dataset.
+    dask_config_kwargs: Dict[str,str], optional
+        Dask configuration settings passed to dask.config.set().
+    dask_cluster_kwargs: dict, optional
+        Dask cluster configuration settings passed to LocalCluster().
+    zarr_version: int, default=3
+        Zarr version to use.
+    """
+    # == Send files to zarr store without dask == #
+    if (dask_config_kwargs is None) and (dask_cluster_kwargs is None):
+        send(file,
+             bucket,
+             object_prefix,
+             store_credentials_json,
+             variables,
+             send_vars_indep,
+             append_dim,
+             grid_filepath,
+             update_coords,
+             rechunk,
+             attrs,
+             zarr_version
+             )
+
+    # == Send files to zarr store with dask == #
+    else:
+        send_with_dask(file,
+                       bucket,
+                       object_prefix,
+                       store_credentials_json,
+                       variables,
+                       send_vars_indep,
+                       append_dim,
+                       grid_filepath,
+                       update_coords,
+                       rechunk,
+                       attrs,
+                       dask_config_kwargs,
+                       dask_cluster_kwargs,
+                       zarr_version
+                       )
+
+
 def update(
         file: list[str] | str,
         bucket: str,
@@ -845,7 +924,7 @@ def update(
                                       parallel=False
                                       )
 
-    # === Update Variables in Existing Zarr Stores === #
+    # === Update Variables in Existing Zarr Store === #
     if send_vars_indep:
         if variables is None:
             variables = list(ds_filepath.data_vars)
@@ -1027,6 +1106,93 @@ def update_with_dask(
         client.shutdown()
         client.close()
         logging.info("Dask Cluster has been shutdown.")
+
+
+def update_zarr(
+    file: list[str] | str,
+    bucket: str,
+    object_prefix: str,
+    store_credentials_json: str,
+    variables: list[str] | str = 'all',
+    send_vars_indep: bool = True,
+    append_dim: str = "time_counter",
+    grid_filepath: Optional[str] = None,
+    update_coords: Optional[dict] = None,
+    rechunk: Optional[dict] = None,
+    attrs: Optional[dict] = None,
+    dask_config_kwargs: Optional[dict] = None,
+    dask_cluster_kwargs: Optional[dict] = None,
+    zarr_version: int = 3
+    ) -> None:
+    """
+    Update existing zarr store in cloud object storage
+    in serial or in parallel using a dask local cluster.
+
+    Parameters
+    ----------
+    file: list | str
+        Regular expression or list of filepaths to netCDF file(s).
+    bucket: str
+        Name of the bucket in the object store. Bucket names can contain only
+        lowercase letters, numbers, dots (.), and hyphens (-).
+    object_prefix: str
+        Prefix to be added to the object names in the object store.
+    store_credentials_json: str
+        Path to the JSON file containing the object store credentials.
+    variables: list, default='all'
+        List of variables to send to zarr stores.
+        If None, all variables will be sent.
+    send_vars_indep: bool, default=True
+        Whether to send variables as separate objects.
+    append_dim: str, default='time_counter'
+        Name of the dimension to append multifile datasets.
+    grid_filepath: str, optional
+        Path to file containing model grid parameter.
+    update_coords: dict, optional
+        Dictionary of coordinate variables to update.
+    rechunk: dict, optional
+        Rechunk strategy dictionary.
+    attrs: dict, optional
+        Attributes to add to the dataset.
+    dask_config_kwargs: Dict[str,str], optional
+        Dask configuration settings passed to dask.config.set().
+    dask_cluster_kwargs: dict, optional
+        Dask cluster configuration settings passed to LocalCluster().
+    zarr_version: int, default=3
+        zarr version to use.
+    """
+    # === Update zarr store without dask === #
+    if (dask_config_kwargs is None) and (dask_cluster_kwargs is None):
+        update(file,
+               bucket,
+               object_prefix,
+               store_credentials_json,
+               variables,
+               send_vars_indep,
+               append_dim,
+               grid_filepath,
+               update_coords,
+               rechunk,
+               attrs,
+               zarr_version
+               )
+    # === Update zarr store with dask === #
+    else:
+        update_with_dask(file,
+                         bucket,
+                         object_prefix,
+                         store_credentials_json,
+                         variables,
+                         send_vars_indep,
+                         append_dim,
+                         grid_filepath,
+                         update_coords,
+                         rechunk,
+                         attrs,
+                         dask_config_kwargs,
+                         dask_cluster_kwargs,
+                         zarr_version
+                         )
 
 
 def list_objects(

--- a/ods/object_store_handler.py
+++ b/ods/object_store_handler.py
@@ -569,7 +569,7 @@ def send(
     ----------
     file: list | str | xarray.Dataset
         Regular expression or list of filepaths to netCDF file(s).
-        Alternatively, users can pass an xarray.Dataset directly.
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).
@@ -649,7 +649,7 @@ def send(
 
 
 def send_with_dask(
-    file: list[str] | str,
+    file: list[str] | str | xr.Dataset,
     bucket: str,
     object_prefix: str,
     store_credentials_json: str,
@@ -666,12 +666,13 @@ def send_with_dask(
     ) -> None:
     """
     Write data in parallel to new zarr store in cloud object storage
-    using dask local cluster.
+    using dask.
 
     Parameters
     ----------
-    file: list | str
+    file: list | str | xarray.Dataset
         Regular expression or list of filepaths to netCDF file(s).
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).
@@ -774,7 +775,7 @@ def send_with_dask(
 
 
 def send_to_zarr(
-    file: list[str] | str,
+    file: list[str] | str | xr.Dataset,
     bucket: str,
     object_prefix: str,
     store_credentials_json: str,
@@ -795,8 +796,9 @@ def send_to_zarr(
 
     Parameters
     ----------
-    file: list | str
+    file: list | str | xarray.Dataset
         Regular expression or list of filepaths to netCDF file(s).
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).
@@ -861,7 +863,7 @@ def send_to_zarr(
 
 
 def update(
-        file: list[str] | str,
+        file: list[str] | str | xr.Dataset,
         bucket: str,
         object_prefix: str,
         store_credentials_json: str,
@@ -876,12 +878,13 @@ def update(
         ) -> None:
     """
     Update existing zarr store in cloud object storage
-    by appending data in serial.
+    by replacing and/or appending data.
 
     Parameters
     ----------
     file: list | str
         Regular expression or list of filepaths to netCDF file(s).
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).
@@ -968,7 +971,7 @@ def update(
 
 
 def update_with_dask(
-    file: list[str] | str,
+    file: list[str] | str | xr.Dataset,
     bucket: str,
     object_prefix: str,
     store_credentials_json: str,
@@ -985,12 +988,13 @@ def update_with_dask(
     ) -> None:
     """
     Update existing zarr store in cloud object storage
-    in parallel using dask local cluster.
+    in parallel using dask.
 
     Parameters
     ----------
-    file: list | str
+    file: list | str | xarray.Dataset
         Regular expression or list of filepaths to netCDF file(s).
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).
@@ -1013,21 +1017,13 @@ def update_with_dask(
         Rechunk strategy dictionary.
     attrs: dict, optional
         Attributes to add to the dataset.
-    dask_config_kwargs: Dict[str,str], optional
+    dask_config_kwargs: dict, optional
         Dask configuration settings passed to dask.config.set().
     dask_cluster_kwargs: dict, optional
         Dask cluster configuration settings passed to LocalCluster().
     zarr_version: int, default=3
         zarr version to use.
     """
-    # === Verify Inputs === #
-    if dask_config_kwargs is not None:
-        if not isinstance(dask_config_kwargs, dict):
-            raise TypeError("dask_config_kwargs must be a dictionary.")
-    if dask_cluster_kwargs is not None:
-        if not isinstance(dask_cluster_kwargs, dict):
-            raise TypeError("dask_cluster_kwargs must be a dictionary.")
-
     # === Configure Cluster === #
     # Update dask configuration settings:
     if dask_config_kwargs is not None:
@@ -1109,7 +1105,7 @@ def update_with_dask(
 
 
 def update_zarr(
-    file: list[str] | str,
+    file: list[str] | str | xr.Dataset,
     bucket: str,
     object_prefix: str,
     store_credentials_json: str,
@@ -1130,8 +1126,9 @@ def update_zarr(
 
     Parameters
     ----------
-    file: list | str
+    file: list | str | xarray.Dataset
         Regular expression or list of filepaths to netCDF file(s).
+        Users can also pass a single xarray.Dataset directly.
     bucket: str
         Name of the bucket in the object store. Bucket names can contain only
         lowercase letters, numbers, dots (.), and hyphens (-).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,8 @@ test = ["pytest >= 7.2.0"]
 Home = "https://github.com/NOC-MSM/OceanDataStore"
 Documentation = "https://noc-msm.github.io/OceanDataStore/"
 
+[tool.setuptools.dynamic]
+version = {attr = "ods.__init__.__version__"}
+
 [project.scripts]
 ods = "ods.cli.main_cli:ods"


### PR DESCRIPTION
- Completed refactor of entry points to `send()`, `send_with_dask()`, `update()` and `update_with_dask()` funcs.

- Added `send_to_zarr()`, `update_zarr()` funcs to be called from main CLI, which call `send()` / `send_with_dask()` according to user specified args.

- Updated README.md and example bash scripts to use latest `send_to_zarr()` and `update_zarr()` funcs.

- Added support for passing xarray Datasets to send and update functions in a scripting context.